### PR TITLE
fix access violation in pthread tls implementation

### DIFF
--- a/libdispatch/platform/windows/pthread_tls.h
+++ b/libdispatch/platform/windows/pthread_tls.h
@@ -191,7 +191,7 @@ static int pthread_setspecific(pthread_key_t key, const void *value)
 {
 	pthread_t t = pthread_self();
 
-	if (key > t->keymax)
+	if (key >= t->keymax)
 	{
 		int keymax = (key + 1) * 2;
 		void **kv = (void**)realloc(t->keyval, keymax * sizeof(void *));

--- a/libpthread_workqueue/src/windows/pthread_tls.h
+++ b/libpthread_workqueue/src/windows/pthread_tls.h
@@ -191,7 +191,7 @@ static int pthread_setspecific(pthread_key_t key, const void *value)
 {
 	pthread_t t = pthread_self();
 
-	if (key > t->keymax)
+	if (key >= t->keymax)
 	{
 		int keymax = (key + 1) * 2;
 		void **kv = (void**)realloc(t->keyval, keymax * sizeof(void *));


### PR DESCRIPTION
dispatch_sync() was sometimes crashing and this patch solves the problem.